### PR TITLE
chore: update ndf parser to fix trailing commas in MAPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@izohek/ndf-parser": "1.2.2",
+    "@izohek/ndf-parser": "1.2.3",
     "@izohek/warno-db": "0.7.5",
     "@oclif/core": "^1",
     "@oclif/plugin-help": "^5",


### PR DESCRIPTION
update ndf parser to fix trailing commas in MAPs found in modded ndf files